### PR TITLE
Fix stats calculation and cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -420,12 +420,12 @@ const ForecastingApp = () => {
   const getUserStats = (userId) => {
     const userForecasts = forecasts.filter(f => f.user_id === userId);
     const resolvedQuestions = questions.filter(q => q.is_resolved);
-    const userResolvedForecasts = userForecasts.filter(f => 
+    const userResolvedForecasts = userForecasts.filter(f =>
       resolvedQuestions.some(q => q.id === f.question_id)
     );
 
     if (userResolvedForecasts.length === 0) {
-      return { brierScore: 0, questionsAnswered: 0, accuracy: 0 };
+      return { brierScore: 0, questionsAnswered: userForecasts.length, accuracy: 0 };
     }
 
     let totalBrierScore = 0;
@@ -447,7 +447,7 @@ const ForecastingApp = () => {
 
     return {
       brierScore: (totalBrierScore / userResolvedForecasts.length).toFixed(3),
-      questionsAnswered: userResolvedForecasts.length,
+      questionsAnswered: userForecasts.length,
       accuracy: userResolvedForecasts.length > 0 ? ((correctPredictions / userResolvedForecasts.length) * 100).toFixed(1) : 0
     };
   };

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -33,6 +33,6 @@ export const getCurrentUser = async () => {
     .select('*')
     .eq('id', user.id)
     .single()
-  
+
   return userData
 }


### PR DESCRIPTION
## Summary
- fix `getUserStats` so questions answered counts all forecasts
- add trailing newline to `supabase.js`

## Testing
- `CI=true npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6844b2e58838832097cf2e54ddeafac4