### PR TITLE
Add signup UI for invited users

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -512,7 +512,14 @@ const ForecastingApp = () => {
 
   // Show login screen if not authenticated
   if (!currentUser) {
-    return <LoginScreen onLogin={login} onResetPassword={resetPassword} error={error} />;
+    return (
+      <LoginScreen
+        onLogin={login}
+        onSignup={signup}
+        onResetPassword={resetPassword}
+        error={error}
+      />
+    );
   }
 
   // Show login screen if not authenticated
@@ -626,11 +633,14 @@ const ForecastingApp = () => {
   );
 };
 
-const LoginScreen = ({ onLogin, onResetPassword, error }) => {
+const LoginScreen = ({ onLogin, onSignup, onResetPassword, error }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
   const [showForgotPassword, setShowForgotPassword] = useState(false);
+  const [showSignup, setShowSignup] = useState(false);
   const [resetSuccess, setResetSuccess] = useState(false);
+  const [signupSuccess, setSignupSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e) => {
@@ -652,6 +662,104 @@ const LoginScreen = ({ onLogin, onResetPassword, error }) => {
       setResetSuccess(true);
     }
   };
+
+  const handleSignup = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    const success = await onSignup(email, password, name);
+    setLoading(false);
+    if (success) {
+      setSignupSuccess(true);
+    }
+  };
+
+  if (showSignup) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
+        <div className="max-w-md w-full space-y-8 p-8">
+          <div className="text-center">
+            <TrendingUp className="mx-auto h-12 w-12 text-blue-600" />
+            <h2 className="mt-6 text-3xl font-bold text-gray-900">Create Account</h2>
+            <p className="mt-2 text-sm text-gray-600">Use your invitation email to sign up</p>
+          </div>
+
+          {signupSuccess ? (
+            <div className="bg-white p-6 rounded-lg shadow-md">
+              <div className="text-center">
+                <Check className="mx-auto h-12 w-12 text-green-600" />
+                <h3 className="mt-4 text-lg font-medium text-gray-900">Account Created</h3>
+                <p className="mt-2 text-sm text-gray-600">You can now sign in with your credentials.</p>
+                <button
+                  onClick={() => {
+                    setShowSignup(false);
+                    setSignupSuccess(false);
+                  }}
+                  className="mt-4 text-blue-600 hover:text-blue-800 underline"
+                >
+                  Back to Login
+                </button>
+              </div>
+            </div>
+          ) : (
+            <form className="mt-8 space-y-6" onSubmit={handleSignup}>
+              <div className="bg-white p-6 rounded-lg shadow-md">
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Name</label>
+                    <input
+                      type="text"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                      placeholder="Your name"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Email</label>
+                    <input
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                      placeholder="you@example.com"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Password</label>
+                    <input
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                      placeholder="Password"
+                      required
+                    />
+                  </div>
+                </div>
+                {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="mt-4 w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                >
+                  {loading ? 'Signing up...' : 'Sign Up'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowSignup(false)}
+                  className="mt-2 w-full text-sm text-gray-600 hover:text-gray-800"
+                >
+                  Back to Login
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   if (showForgotPassword) {
     return (
@@ -769,6 +877,13 @@ const LoginScreen = ({ onLogin, onResetPassword, error }) => {
               className="mt-2 w-full text-sm text-gray-600 hover:text-gray-800 underline"
             >
               Forgot Password?
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowSignup(true)}
+              className="mt-2 w-full text-sm text-gray-600 hover:text-gray-800 underline"
+            >
+              Sign Up
             </button>
             <div className="mt-4 text-xs text-gray-500">
               <p><strong>Demo Accounts (for testing):</strong></p>


### PR DESCRIPTION
## Summary
- provide `onSignup` prop to `LoginScreen`
- add signup form and success message inside login component
- link new signup form from login page

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6845bc3404f48320bcc23ecec59294d2