### PR TITLE
Add delete actions and reset password page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,20 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import Signup from './pages/Signup';
+import ResetPassword from './pages/ResetPassword';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 const path = window.location.pathname;
 root.render(
   <React.StrictMode>
-    {path.startsWith('/signup') ? <Signup /> : <App />}
+    {path.startsWith('/signup') ? (
+      <Signup />
+    ) : path.startsWith('/reset-password') ? (
+      <ResetPassword />
+    ) : (
+      <App />
+    )}
   </React.StrictMode>
 );
 

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from '../supabase';
+
+const ResetPassword = () => {
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const access_token = params.get('access_token');
+    const refresh_token = params.get('refresh_token');
+    if (access_token && refresh_token) {
+      supabase.auth.setSession({ access_token, refresh_token });
+    }
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (password !== confirm) {
+      setMessage('Passwords do not match');
+      return;
+    }
+    setLoading(true);
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) {
+      setMessage(error.message);
+    } else {
+      setMessage('Password updated');
+      setTimeout(() => {
+        window.location.href = '/';
+      }, 1500);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md space-y-4 w-full max-w-md">
+        <h2 className="text-xl font-bold text-gray-900 text-center">Reset Password</h2>
+        <div>
+          <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md" placeholder="New password" required />
+        </div>
+        <div>
+          <input type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md" placeholder="Confirm password" required />
+        </div>
+        {message && <p className="text-sm text-red-600">{message}</p>}
+        <button type="submit" disabled={loading} className="w-full bg-blue-600 text-white py-2 rounded-md">
+          {loading ? 'Updating...' : 'Update Password'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -9,6 +9,12 @@ if (!supabaseUrl || !supabaseKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseKey)
 
+// Optional admin client for server-side operations
+const serviceRoleKey = process.env.REACT_APP_SUPABASE_SERVICE_ROLE_KEY
+export const supabaseAdmin = serviceRoleKey
+  ? createClient(supabaseUrl, serviceRoleKey)
+  : null
+
 // Helper function to check if user is admin
 export const isAdmin = async () => {
   const { data: { user } } = await supabase.auth.getUser()


### PR DESCRIPTION
## Summary
- allow admins to delete questions and users
- show toast messages on deletion
- add reset-password page and update reset link
- expose optional Supabase admin client
- route reset-password page from index

## Testing
- `npm test --silent` *(fails: opens interactive mode)*

------
https://chatgpt.com/codex/tasks/task_e_68467c86a4c88320a789e396ff183a6b