### PR TITLE
Fix reset password redirect URL

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -227,8 +227,13 @@ const ForecastingApp = () => {
     try {
       setError('');
       
+      const siteUrl =
+        process.env.NEXT_PUBLIC_SITE_URL ||
+        process.env.REACT_APP_SITE_URL ||
+        window.location.origin;
+
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/reset-password`
+        redirectTo: `${siteUrl}/reset-password`
       });
   
       if (error) throw error;


### PR DESCRIPTION
## Summary
- handle multiple environment variable names when redirecting reset-password email

## Testing
- `CI=1 npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684708c3767483208bbc98d5abfe3b9b