### PR TITLE
Add user invitation SQL migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ your Supabase project. This function should call the database RPC
 `create_user_invitation` and return its JSON response. A reference
 implementation is provided under `supabase/functions/invite-user`.
 
+The underlying database function is defined in
+`supabase/migrations/000_create_user_invitation.sql`. Run
+`npm run db:init` to execute this migration on a new Supabase project
+before invoking the edge function.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "db:init": "supabase db execute ./supabase/migrations/000_create_user_invitation.sql"
   },
   "eslintConfig": {
     "extends": [

--- a/supabase/migrations/000_create_user_invitation.sql
+++ b/supabase/migrations/000_create_user_invitation.sql
@@ -1,0 +1,42 @@
+-- Creates table and function for managing user invitations
+
+-- Enable pgcrypto for gen_random_uuid if not already
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS public.user_invitations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    email text NOT NULL UNIQUE,
+    name text,
+    role text NOT NULL DEFAULT 'forecaster',
+    invited_by uuid REFERENCES auth.users(id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL DEFAULT now() + interval '7 days',
+    used_at timestamptz
+);
+
+CREATE OR REPLACE FUNCTION public.create_user_invitation(
+    user_email text,
+    user_name text DEFAULT '',
+    user_role text DEFAULT 'forecaster'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    rec user_invitations;
+BEGIN
+    INSERT INTO public.user_invitations(email, name, role, invited_by)
+    VALUES (user_email, user_name, user_role, auth.uid())
+    ON CONFLICT (email) DO UPDATE
+       SET name = EXCLUDED.name,
+           role = EXCLUDED.role,
+           invited_by = auth.uid(),
+           created_at = now(),
+           expires_at = now() + interval '7 days'
+    RETURNING * INTO rec;
+
+    RETURN to_jsonb(rec);
+END;
+$$;


### PR DESCRIPTION
## Summary
- create SQL migration defining `create_user_invitation`
- add a script to apply the migration
- document the setup step in the README

## Testing
- `npm test --silent` *(fails: No tests found related to files changed since last commit)*

------
https://chatgpt.com/codex/tasks/task_e_6847c65915b08320843acacc99c54038