### PR TITLE
Fix delete user via serverless function

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, TrendingUp, Users, Award, Settings, Plus, Eye, EyeOff, Lock, User, BarChart3, Clock, Target, Trophy, Globe, AlertCircle, Check, Trash } from 'lucide-react';
-import { supabase, supabaseAdmin, getCurrentUser, isAdmin } from './supabase';
+import { supabase, getCurrentUser, isAdmin } from './supabase';
 
 const ForecastingApp = () => {
   const [currentUser, setCurrentUser] = useState(null);
@@ -314,12 +314,9 @@ const ForecastingApp = () => {
         return true;
       }
 
-      if (supabaseAdmin) {
-        const { error: authError } = await supabaseAdmin.auth.admin.deleteUser(uid);
-        if (authError) throw authError;
-      }
-
-      const { error } = await supabase.from('users').delete().eq('id', uid);
+      const { error } = await supabase.functions.invoke('delete-user', {
+        body: { uid }
+      });
       if (error) throw error;
 
       await loadAppData();

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,0 +1,46 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const { uid } = await req.json();
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const { error: authError } = await supabase.auth.admin.deleteUser(uid);
+    if (authError) {
+      return new Response(JSON.stringify({ error: authError.message }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" }
+      });
+    }
+
+    const { error } = await supabase.from('users').delete().eq('id', uid);
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" }
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" }
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a new `delete-user` Edge Function to remove auth and profile data
- update `deleteUser` in the React app to call the new function
- remove unused `supabaseAdmin` import

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849ba6322148320a64b5d00c78762f1