### PR TITLE
Add dynamic economic news widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ environment variables are configured:
 - `REACT_APP_SUPABASE_ANON_KEY`
 - Optional: `REACT_APP_SUPABASE_SERVICE_ROLE_KEY`
 - Optional: `INVITE_REDIRECT_URL` - redirect URL for invitation links
+- Optional: `REACT_APP_NEWS_API_KEY` - NewsAPI key for the Economic News widget
+- Optional: `REACT_APP_GUARDIAN_API_KEY` - Guardian Open Platform key used when NewsAPI quota is exhausted
 
 These values must be provided before running `npm run build` or starting a
 deployment.

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import useNewsFeed from './hooks/useNewsFeed';
 import { Calendar, TrendingUp, Users, Award, Settings, Plus, Eye, EyeOff, Lock, User, BarChart3, Clock, Target, Trophy, Globe, AlertCircle, Check, Trash } from 'lucide-react';
 
 import { supabase, getCurrentUser, isAdmin } from './supabase';
@@ -245,13 +246,8 @@ const ForecastingApp = () => {
     setQuestions(sampleQuestions);
   }, []);
 
-  // Sample news feed
-  const newsFeed = [
-    { title: "Fed Officials Signal Cautious Approach to Rate Changes", source: "Reuters", url: "#" },
-    { title: "Unemployment Claims Drop to Lowest Level This Year", source: "Bloomberg", url: "#" },
-    { title: "Q1 GDP Growth Exceeds Expectations at 3.2%", source: "Wall Street Journal", url: "#" },
-    { title: "Tech Sector Leads Market Rally Amid AI Optimism", source: "Financial Times", url: "#" }
-  ];
+  // Economic news headlines
+  const newsFeed = useNewsFeed('economy');
 
  // Authentication functions
   const login = async (email, password) => {

--- a/src/hooks/useNewsFeed.js
+++ b/src/hooks/useNewsFeed.js
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+
+const NEWS_TTL_MS = 1000 * 60 * 480; // 8 hours
+const STORAGE_KEY = 'newsFeedCache';
+
+export default function useNewsFeed(topic = 'economy') {
+  const [news, setNews] = useState([]);
+
+  useEffect(() => {
+    const fetchNews = async () => {
+      const cached = localStorage.getItem(STORAGE_KEY);
+      if (cached) {
+        try {
+          const { data, timestamp } = JSON.parse(cached);
+          if (Date.now() - timestamp < NEWS_TTL_MS) {
+            setNews(data);
+            return;
+          }
+        } catch (err) {
+          console.error('Failed to parse cached news', err);
+        }
+      }
+
+      let items = [];
+
+      const newsApiKey = process.env.REACT_APP_NEWS_API_KEY;
+      if (newsApiKey) {
+        try {
+          const url = `https://newsapi.org/v2/top-headlines?q=${encodeURIComponent(topic)}&sources=ap,bbc-news,reuters,npr,the-guardian-uk&language=en&apiKey=${newsApiKey}`;
+          const res = await fetch(url);
+          if (res.ok) {
+            const json = await res.json();
+            items = json.articles.map(a => ({
+              title: a.title,
+              url: a.url,
+              source: a.source?.name || 'NewsAPI'
+            }));
+          }
+        } catch (err) {
+          console.error('NewsAPI error', err);
+        }
+      }
+
+      if (items.length === 0) {
+        const guardianKey = process.env.REACT_APP_GUARDIAN_API_KEY || 'test';
+        try {
+          const url = `https://content.guardianapis.com/search?q=${encodeURIComponent(topic)}&api-key=${guardianKey}`;
+          const res = await fetch(url);
+          if (res.ok) {
+            const json = await res.json();
+            items = json.response.results.map(r => ({
+              title: r.webTitle,
+              url: r.webUrl,
+              source: 'The Guardian'
+            }));
+          }
+        } catch (err) {
+          console.error('Guardian API error', err);
+        }
+      }
+
+      setNews(items);
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ data: items, timestamp: Date.now() }));
+      } catch (err) {
+        console.error('Failed to cache news', err);
+      }
+    };
+
+    fetchNews();
+  }, [topic]);
+
+  return news;
+}


### PR DESCRIPTION
## Summary
- fetch economic headlines with new `useNewsFeed` hook
- hook caches results for 8 hours and falls back to Guardian API
- wire widget into dashboard
- document News API environment variables

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684ba1e602f0832099f0d648826f7e1c