### PR TITLE
Improve question-based news search

### DIFF
--- a/src/hooks/useNewsFeed.js
+++ b/src/hooks/useNewsFeed.js
@@ -3,7 +3,23 @@ import { useState, useEffect } from 'react';
 const NEWS_TTL_MS = 1000 * 60 * 480; // 8 hours
 const STORAGE_KEY = 'newsFeedCache';
 
-export default function useNewsFeed(topic = 'economy') {
+const STOP_WORDS = new Set([
+  'the','a','an','of','for','on','in','and','or','is','are','to','will','with',
+  'by','from','it','that','this','which','at','as','be'
+]);
+
+function extractKeywords(questions) {
+  const text = questions.join(' ').toLowerCase();
+  const tokens = text.match(/\b[a-z]+\b/g) || [];
+  const filtered = tokens.filter(t => !STOP_WORDS.has(t));
+  return Array.from(new Set(filtered));
+}
+
+export default function useNewsFeed(
+  topic = 'economy',
+  questions,
+  daysBack = 35
+) {
   const [news, setNews] = useState([]);
 
   useEffect(() => {
@@ -23,17 +39,26 @@ export default function useNewsFeed(topic = 'economy') {
 
       let items = [];
 
+      const keywords = Array.isArray(questions) && questions.length
+        ? extractKeywords(questions)
+        : topic.split(/\s+/);
+      const searchQuery = encodeURIComponent(keywords.join(' '));
+      const fromDate = new Date(Date.now() - daysBack * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split('T')[0];
+
       const newsApiKey = process.env.REACT_APP_NEWS_API_KEY;
       if (newsApiKey) {
         try {
-          const url = `https://newsapi.org/v2/top-headlines?q=${encodeURIComponent(topic)}&sources=ap,bbc-news,reuters,npr,the-guardian-uk&language=en&apiKey=${newsApiKey}`;
+          const url = `https://newsapi.org/v2/everything?q=${searchQuery}&sources=ap,bbc-news,reuters,npr,the-guardian-uk&language=en&from=${fromDate}&sortBy=publishedAt&apiKey=${newsApiKey}`;
           const res = await fetch(url);
           if (res.ok) {
             const json = await res.json();
             items = json.articles.map(a => ({
               title: a.title,
               url: a.url,
-              source: a.source?.name || 'NewsAPI'
+              source: a.source?.name || 'NewsAPI',
+              publishedAt: a.publishedAt
             }));
           }
         } catch (err) {
@@ -41,23 +66,25 @@ export default function useNewsFeed(topic = 'economy') {
         }
       }
 
-      if (items.length === 0) {
-        const guardianKey = process.env.REACT_APP_GUARDIAN_API_KEY || 'test';
-        try {
-          const url = `https://content.guardianapis.com/search?q=${encodeURIComponent(topic)}&api-key=${guardianKey}`;
-          const res = await fetch(url);
-          if (res.ok) {
-            const json = await res.json();
-            items = json.response.results.map(r => ({
-              title: r.webTitle,
-              url: r.webUrl,
-              source: 'The Guardian'
-            }));
-          }
-        } catch (err) {
-          console.error('Guardian API error', err);
+      const guardianKey = process.env.REACT_APP_GUARDIAN_API_KEY || 'test';
+      try {
+        const url = `https://content.guardianapis.com/search?q=${searchQuery}&from-date=${fromDate}&order-by=newest&api-key=${guardianKey}`;
+        const res = await fetch(url);
+        if (res.ok) {
+          const json = await res.json();
+          const guardianItems = json.response.results.map(r => ({
+            title: r.webTitle,
+            url: r.webUrl,
+            source: 'The Guardian',
+            publishedAt: r.webPublicationDate
+          }));
+          items = items.concat(guardianItems);
         }
+      } catch (err) {
+        console.error('Guardian API error', err);
       }
+
+      items.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
 
       setNews(items);
       try {
@@ -68,7 +95,7 @@ export default function useNewsFeed(topic = 'economy') {
     };
 
     fetchNews();
-  }, [topic]);
+  }, [topic, questions, daysBack]);
 
   return news;
 }


### PR DESCRIPTION
## Summary
- enhance `useNewsFeed` to accept `questions` and `daysBack`
- build combined keyword queries
- search NewsAPI and Guardian using same query and filter by date
- merge and sort stories by publication time before caching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb24a62948320b36f2a4f67ccf07b