### PR TITLE
Fix leaderboard after resolving questions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2415,9 +2415,9 @@ const QuestionManagementCard = ({ question, forecasts, onResolve, onUpdate, onDe
   const [resolution, setResolution] = useState('');
   const questionForecasts = forecasts.filter(f => f.question_id === question.id);
 
-  const handleResolve = () => {
+  const handleResolve = async () => {
     if (resolution) {
-      onResolve(question.id, resolution);
+      await onResolve(question.id, resolution);
       setShowResolve(false);
       setResolution('');
     }


### PR DESCRIPTION
## Summary
- await the asynchronous question resolution to ensure fresh data loads

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684bbf50f6448320aaa8be889b0311a5