### PR TITLE
Show admins on leaderboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -698,7 +698,6 @@ const ForecastingApp = () => {
 
   const getLeaderboard = () => {
     return users
-      .filter(u => u.role === 'forecaster')
       .map(user => ({
         ...user,
         stats: getUserStats(user.id)


### PR DESCRIPTION
## Summary
- allow all users to appear on leaderboard, not just forecasters

## Testing
- `npm test --silent` *(fails: "No tests found related to files changed since last commit.")*

------
https://chatgpt.com/codex/tasks/task_e_684cefd93fdc8320a5c8378390127708