### PR TITLE
Graceful fallback for missing Supabase env

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ environment variables are configured:
 These values must be provided before running `npm run build` or starting a
 deployment.
 
+If `REACT_APP_SUPABASE_URL` or `REACT_APP_SUPABASE_ANON_KEY` are missing during
+local development, the app will log a warning and disable the Supabase client.
+However a production build will not be functional without these variables, so
+ensure they are configured in your deployment environment.
+
 ## Supabase Edge Function
 
 The application expects an Edge Function named `invite-user` to be deployed to

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -4,19 +4,26 @@ const supabaseUrl = process.env.REACT_APP_SUPABASE_URL
 const supabaseKey = process.env.REACT_APP_SUPABASE_ANON_KEY
 
 if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Missing Supabase environment variables')
+  console.warn(
+    'Supabase environment variables are missing. The client will be disabled.'
+  )
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey)
+export const supabase =
+  supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null
 
 // Optional admin client for server-side operations
 const serviceRoleKey = process.env.REACT_APP_SUPABASE_SERVICE_ROLE_KEY
-export const supabaseAdmin = serviceRoleKey
-  ? createClient(supabaseUrl, serviceRoleKey)
-  : null
+export const supabaseAdmin =
+  supabaseUrl && serviceRoleKey ? createClient(supabaseUrl, serviceRoleKey) : null
 
 // Helper function to check if user is admin
 export const isAdmin = async () => {
+  if (!supabase) {
+    console.warn('Supabase client not initialized')
+    return false
+  }
+
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return false
   
@@ -31,6 +38,11 @@ export const isAdmin = async () => {
 
 // Helper function to get current user profile
 export const getCurrentUser = async () => {
+  if (!supabase) {
+    console.warn('Supabase client not initialized')
+    return null
+  }
+
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return null
   


### PR DESCRIPTION
## Summary
- avoid throwing when Supabase environment variables are missing
- guard `isAdmin` and `getCurrentUser` when client is null
- clarify local dev vs production requirements in README

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68558656dd008320ba7d1007291bec80