### PR TITLE
Handle optional Guardian key

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ deploying the project. The following environment variables are supported:
 - Optional: `REACT_APP_SUPABASE_SERVICE_ROLE_KEY`
 - Optional: `INVITE_REDIRECT_URL` - redirect URL for invitation links
 - Optional: `REACT_APP_NEWS_API_KEY` - NewsAPI key for the Economic News widget
-- Optional: `REACT_APP_GUARDIAN_API_KEY` - Guardian Open Platform key used when NewsAPI quota is exhausted
+- Optional: `REACT_APP_GUARDIAN_API_KEY` - Guardian Open Platform key for additional news from The Guardian (request skipped if unset)
 
 These values must be provided before running `npm run build` or starting a
 deployment.

--- a/src/hooks/useNewsFeed.js
+++ b/src/hooks/useNewsFeed.js
@@ -66,22 +66,26 @@ export default function useNewsFeed(
         }
       }
 
-      const guardianKey = process.env.REACT_APP_GUARDIAN_API_KEY || 'test';
-      try {
-        const url = `https://content.guardianapis.com/search?q=${searchQuery}&from-date=${fromDate}&order-by=newest&api-key=${guardianKey}`;
-        const res = await fetch(url);
-        if (res.ok) {
-          const json = await res.json();
-          const guardianItems = json.response.results.map(r => ({
-            title: r.webTitle,
-            url: r.webUrl,
-            source: 'The Guardian',
-            publishedAt: r.webPublicationDate
-          }));
-          items = items.concat(guardianItems);
+      const guardianKey = process.env.REACT_APP_GUARDIAN_API_KEY;
+      if (guardianKey) {
+        try {
+          const url = `https://content.guardianapis.com/search?q=${searchQuery}&from-date=${fromDate}&order-by=newest&api-key=${guardianKey}`;
+          const res = await fetch(url);
+          if (res.ok) {
+            const json = await res.json();
+            const guardianItems = json.response.results.map(r => ({
+              title: r.webTitle,
+              url: r.webUrl,
+              source: 'The Guardian',
+              publishedAt: r.webPublicationDate
+            }));
+            items = items.concat(guardianItems);
+          }
+        } catch (err) {
+          console.error('Guardian API error', err);
         }
-      } catch (err) {
-        console.error('Guardian API error', err);
+      } else {
+        console.warn('Guardian API key missing, skipping Guardian news fetch');
       }
 
       items.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));


### PR DESCRIPTION
## Summary
- skip Guardian API fetch when `REACT_APP_GUARDIAN_API_KEY` is missing
- note in README that Guardian API key is optional and the request is skipped if unset

## Testing
- `npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6855897355a88320a43fd7ac418d9df7