### PR TITLE
Handle invalid Supabase session

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ local development, the app will log a warning and disable the Supabase client.
 However a production build will not be functional without these variables, so
 ensure they are configured in your deployment environment.
 
+If you deploy multiple Supabase apps to the same domain, set a unique storage
+key for the auth client. The default in this project is `forecasting-app.auth`.
+This prevents one app from overwriting another's session and helps avoid errors
+such as "Invalid Refresh Token" after a browser refresh.
+
 ## Supabase Edge Function
 
 The application expects an Edge Function named `invite-user` to be deployed to

--- a/src/App.js
+++ b/src/App.js
@@ -107,6 +107,18 @@ const ForecastingApp = () => {
         }
       } catch (error) {
         console.error('Error initializing app:', error);
+        if (
+          error?.message &&
+          error.message.toLowerCase().includes('invalid refresh token')
+        ) {
+          // Clear any invalid session so the user can log in again
+          try {
+            await supabase.auth.signOut();
+          } catch (signOutError) {
+            console.error('Error signing out after refresh failure:', signOutError);
+          }
+          localStorage.removeItem('forecasting-app.auth');
+        }
         setError('Failed to initialize app');
       } finally {
         setLoading(false);

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -10,7 +10,14 @@ if (!supabaseUrl || !supabaseKey) {
 }
 
 export const supabase =
-  supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null
+  supabaseUrl && supabaseKey
+    ? createClient(supabaseUrl, supabaseKey, {
+        auth: {
+          // Avoid conflicts when multiple Supabase apps share the same browser context
+          storageKey: 'forecasting-app.auth'
+        }
+      })
+    : null
 
 // Optional admin client for server-side operations
 const serviceRoleKey = process.env.REACT_APP_SUPABASE_SERVICE_ROLE_KEY


### PR DESCRIPTION
## Summary
- avoid GoTrue client storage collisions by setting a unique storage key
- clear invalid sessions when Supabase refresh tokens are rejected
- document the storage key in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855e190bc40832092711a0ecae8c383