### PR TITLE
Fix multiple auth client warning

### DIFF
--- a/src/supabase.js
+++ b/src/supabase.js
@@ -22,7 +22,17 @@ export const supabase =
 // Optional admin client for server-side operations
 const serviceRoleKey = process.env.REACT_APP_SUPABASE_SERVICE_ROLE_KEY
 export const supabaseAdmin =
-  supabaseUrl && serviceRoleKey ? createClient(supabaseUrl, serviceRoleKey) : null
+  supabaseUrl && serviceRoleKey
+    ? createClient(supabaseUrl, serviceRoleKey, {
+        auth: {
+          // Use a separate storage key and disable session persistence to avoid
+          // conflicts with the main client in the browser
+          storageKey: 'forecasting-app.admin-auth',
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      })
+    : null
 
 // Helper function to check if user is admin
 export const isAdmin = async () => {


### PR DESCRIPTION
## Summary
- avoid storing session for admin Supabase client

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6856390963748320aa3afd127b1bec04