### PR TITLE
Fix export placement for CodeAnalyzer

### DIFF
--- a/src/utils/codeAnalyzer.js
+++ b/src/utils/codeAnalyzer.js
@@ -7,8 +7,6 @@ class CodeAnalyzer {
     this.setupDetection();
   }
 
-// Create singleton instance
-export const codeAnalyzer = new CodeAnalyzer();
 
   setupDetection() {
     // Check for Supabase instances in window
@@ -254,3 +252,6 @@ export const codeAnalyzer = new CodeAnalyzer();
     return recommendations;
   }
 }
+
+// Create singleton instance
+export const codeAnalyzer = new CodeAnalyzer();


### PR DESCRIPTION
## Summary
- fix invalid export placement in `codeAnalyzer.js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a175e39c08320a713ceda8445944b