### PR TITLE
Fix global diagnostics variable

### DIFF
--- a/src/utils/masterDiagnostics.js
+++ b/src/utils/masterDiagnostics.js
@@ -299,6 +299,11 @@ window.diagnostics = {
   serviceWorker: serviceWorkerDetector
 };
 
+// Ensure global access via `diagnostics` in browser consoles
+if (typeof globalThis !== 'undefined') {
+  globalThis.diagnostics = window.diagnostics;
+}
+
 console.log(`
 🏥 Diagnostics Loaded! Available commands:
   • diagnostics.run()      - Run full diagnostic scan


### PR DESCRIPTION
## Summary
- expose diagnostics via `globalThis` so `diagnostics.run()` works from the browser console

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a210107848320ac8fe267165d4af8