### PR TITLE
Fix global diagnostics variable

### DIFF
--- a/src/utils/masterDiagnostics.js
+++ b/src/utils/masterDiagnostics.js
@@ -1,5 +1,6 @@
 // src/utils/masterDiagnostics.js
 
+/* global globalThis */
 import { getBrowserDetails } from './diagnostics';
 import { consoleLogger } from './consoleLogger';
 import { networkMonitor } from './networkMonitor';
@@ -298,6 +299,11 @@ window.diagnostics = {
   code: codeAnalyzer,
   serviceWorker: serviceWorkerDetector
 };
+
+// Ensure global access via `diagnostics` in browser consoles
+if (typeof globalThis !== 'undefined') {
+  globalThis.diagnostics = window.diagnostics;
+}
 
 console.log(`
 🏥 Diagnostics Loaded! Available commands:


### PR DESCRIPTION
## Summary
- expose diagnostics via `globalThis` so `diagnostics.run()` works from the browser console
- annotate `globalThis` as a known global to appease ESLint

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a210107848320ac8fe267165d4af8