### PR TITLE
Remove demo credentials from login page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1150,11 +1150,6 @@ const LoginScreen = ({ onLogin, onSignup, onResetPassword, error }) => {
             >
               Sign Up
             </button>
-            <div className="mt-4 text-xs text-gray-500">
-              <p><strong>Demo Accounts (for testing):</strong></p>
-              <p>Admin: admin@company.com / admin123</p>
-              <p>Forecaster: forecaster1@company.com / forecast123</p>
-            </div>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- remove the demo account info banner from LoginScreen

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_685b65bbd3448320ad1486a05729ad59