### PR TITLE
Fix duplicate user record error during signup

### DIFF
--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -45,14 +45,19 @@ const Signup = () => {
       } = await supabase.auth.getUser();
       if (userError || !user) throw userError || new Error('User not found');
 
-      const { error: insertError } = await supabase.from('users').insert({
-        id: user.id,
-        name,
-        email: user.email,
-        role: 'forecaster',
-        must_change_password: false
-      });
-      if (insertError) throw insertError;
+      const { error: upsertError } = await supabase
+        .from('users')
+        .upsert(
+          {
+            id: user.id,
+            name,
+            email: user.email,
+            role: 'forecaster',
+            must_change_password: false
+          },
+          { onConflict: 'id' }
+        );
+      if (upsertError) throw upsertError;
 
       window.location.href = '/';
     } catch (err) {


### PR DESCRIPTION
## Summary
- handle existing records by upserting user profile in the signup page

## Testing
- `npm test -- -w=0` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc857f77483209d9967086fa9273e