### PR TITLE
Remove related article information from news section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1307,17 +1307,6 @@ const DashboardView = ({ currentUser, questions, forecasts, getUserStats, newsFe
                     {item.title}
                   </a>
                   <p className="text-xs text-slate-500 mt-1">{item.source}</p>
-                  {item.relatedQuestions && item.relatedQuestions.length > 0 && (
-                    <p className="text-xs text-slate-500 mt-1">
-                      Related to:{' '}
-                      {item.relatedQuestions.map((qid, i) => (
-                        <span key={qid}>
-                          {questionMap[qid]}
-                          {i < item.relatedQuestions.length - 1 ? ', ' : ''}
-                        </span>
-                      ))}
-                    </p>
-                  )}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- remove rendering of 'Related to' data in the Dashboard news feed

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_685d6e43590c8320b020ab3709764233