### PR TITLE
Remove unused extractKeywords helper

### DIFF
--- a/src/hooks/useNewsFeed.js
+++ b/src/hooks/useNewsFeed.js
@@ -14,10 +14,6 @@ function extractKeywordsFromText(text) {
   return Array.from(new Set(filtered));
 }
 
-function extractKeywords(questions) {
-  const text = questions.join(' ');
-  return extractKeywordsFromText(text);
-}
 
 export default function useNewsFeed(
   topic = 'economy',


### PR DESCRIPTION
## Summary
- delete the leftover `extractKeywords` helper
- use `extractKeywordsFromText` directly for keyword parsing

## Testing
- `npx eslint src/hooks/useNewsFeed.js`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68601fcd68888320bd5ce1242cd518e0