### PR TITLE
Improve signup token parsing

### DIFF
--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -8,7 +8,13 @@ const Signup = () => {
   const searchParams = new URLSearchParams(window.location.search);
   const hashParams = new URLSearchParams(window.location.hash.slice(1));
 
-  const token = searchParams.get('token') || hashParams.get('token') || '';
+  // Supabase may return the invitation verifier as either `token` or `code`.
+  const token =
+    searchParams.get('token') ||
+    searchParams.get('code') ||
+    hashParams.get('token') ||
+    hashParams.get('code') ||
+    '';
   const access_token = hashParams.get('access_token');
   const refresh_token = hashParams.get('refresh_token');
 


### PR DESCRIPTION
## Summary
- parse both `token` and `code` parameters in the signup page

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861abe4d950832097ea20e941b8190c