### PR TITLE
Fix invalid refresh errors docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ key for the auth client. The default in this project is `forecasting-app.auth`.
 This prevents one app from overwriting another's session and helps avoid errors
 such as "Invalid Refresh Token" after a browser refresh.
 
+You can customize this value by editing the `AUTH_STORAGE_PREFIX` constant in
+`src/supabase.js`. If an "Invalid Refresh Token" error does occur, the
+application's `validateSession` logic will automatically clear the stored
+session and sign the user out. After the stale session is removed, simply log in
+again to obtain a fresh session.
+
 ## Supabase Edge Function
 
 The application expects an Edge Function named `invite-user` to be deployed to


### PR DESCRIPTION
## Summary
- document customizing the Supabase auth storage key
- explain how the app clears invalid refresh token sessions

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68634efbbd5083209f2b444d2291a733