### PR TITLE
Update auth storage prefix configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ REACT_APP_SUPABASE_URL=
 
 REACT_APP_SUPABASE_ANON_KEY=
 
+# Optional: Storage key prefix used by Supabase auth. Change it if multiple
+# Supabase apps run on the same domain to prevent conflicts.
+REACT_APP_AUTH_STORAGE_PREFIX=
+
 INVITE_REDIRECT_URL=
 
 SUPABASE

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ key for the auth client. The default in this project is `forecasting-app.auth`.
 This prevents one app from overwriting another's session and helps avoid errors
 such as "Invalid Refresh Token" after a browser refresh.
 
-You can customize this value by editing the `AUTH_STORAGE_PREFIX` constant in
-`src/supabase.js`. If an "Invalid Refresh Token" error does occur, the
-application's `validateSession` logic will automatically clear the stored
-session and sign the user out. After the stale session is removed, simply log in
-again to obtain a fresh session.
+You can customize this value either by editing the `AUTH_STORAGE_PREFIX`
+constant in `src/supabase.js` or by setting the
+`REACT_APP_AUTH_STORAGE_PREFIX` environment variable. If an "Invalid Refresh
+Token" error does occur, the application's `validateSession` logic will
+automatically clear the stored session and sign the user out. After the stale
+session is removed, simply log in again to obtain a fresh session.
 
 ## Supabase Edge Function
 

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -9,7 +9,10 @@ if (!supabaseUrl || !supabaseKey) {
   )
 }
 
-export const AUTH_STORAGE_PREFIX = 'forecasting-app.auth'
+// Allow the auth storage key to be customized via env var so
+// multiple Supabase apps on the same domain don't clash.
+export const AUTH_STORAGE_PREFIX =
+  process.env.REACT_APP_AUTH_STORAGE_PREFIX || 'forecasting-app.auth'
 
 // Ensure we only ever create a single Supabase client, even during
 // React fast refresh/hot module replacement.  We store the instance on


### PR DESCRIPTION
## Summary
- allow customizing Supabase auth storage key via `REACT_APP_AUTH_STORAGE_PREFIX`
- document the new variable in README and `.env.example`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68641054bfe083209b9684aa945538ee